### PR TITLE
Make encrypt future compatible

### DIFF
--- a/classes/PaynowCompatibilityHelper.php
+++ b/classes/PaynowCompatibilityHelper.php
@@ -1,27 +1,23 @@
 <?php
 
 /**
- * NOTICE OF LICENSE
- *
- * This source file is subject to the MIT License (MIT)
- * that is bundled with this package in the file LICENSE.md.
- *
- * @author mElements S.A.
- * @copyright mElements S.A.
- * @license   MIT License
- */
+* NOTICE OF LICENSE
+*
+* This source file is subject to the MIT License (MIT)
+* that is bundled with this package in the file LICENSE.md.
+*
+* @author mElements S.A.
+* @copyright mElements S.A.
+* @license   MIT License
+*/
 
 class PaynowCompatibilityHelper
 {
-    public static function encrypt($to_encrypt)
-    {
-		if (method_exists('Tools', 'hash')) {
-			return Tools::hash($to_encrypt);
-		} else {
-			return Tools::encrypt($to_encrypt);
-		}
-    }
-
+	public static function encrypt($to_encrypt)
+	{
+		return md5(_COOKIE_KEY_.$to_encrypt);
+	}
+	
 	public static function redirect($url)
 	{
 		if (method_exists('Tools', 'redirect')) {


### PR DESCRIPTION
Use deterministic hashing for log names

PS uses MD5 (stable), while thirty bees uses `password_hash` (non-deterministic), resulting in random log filenames on each generation.

Since this module works on PS 1.6 and PHP 7.2 it also works good on thirty bees 1.6